### PR TITLE
Fix redundant scroll arrows

### DIFF
--- a/src/component/option-list.js
+++ b/src/component/option-list.js
@@ -30,7 +30,10 @@ OptionList.prototype.on = function on(channel, callback) {
 OptionList.prototype.init = function init() {
   const $items = $('<div/>')
     .addClass('ui-virtual-select--items')
-    .css('overflow-y', 'scroll')
+    .css({
+      'overflow-y': 'auto',
+      'box-sizing': 'content-box'
+    })
     .on('scroll', throttle(() => {
       this.render(this.renderedState);
     }, 10))


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/4129781/87243458-d3e15d80-c43e-11ea-9629-796e8c20cace.png)

After:
![image](https://user-images.githubusercontent.com/4129781/87243464-d80d7b00-c43e-11ea-9c77-7305e1e2c606.png)

By the way, it would be nice to get a message such as "no items found" when there's no match.
Thanks for publishing this library!